### PR TITLE
Disable vsync by default.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1138,7 +1138,7 @@ function defaultconfig()
 	scale = 2
 	volume = 1
 	mappack = "smb"
-	vsync = true
+	vsync = false
 
 	reachedworlds = {}
 end


### PR DESCRIPTION
When I disable vsync in the options its back on on the next start.
Had to disable it in `defaultconfig` to make it stick.

As a side effect it is now disabled on the first start (if there is no `options.txt`).
Not sure if that is desired.

Maybe the real fix is implementing a novsync option in the text file, and turn this around.
But I'm not that experienced in lua...

I want to use this opportunity to thank you for your work.
This concept (mario+portal) is really fun! 