### PR TITLE
Build executables

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,0 +1,49 @@
+name: Compile
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: main
+        submodules: true
+      name: Checkout Repository
+    - name: Extract Metadata
+      id: metadata
+      run: python3 main/_DO_NOT_INCLUDE/extract-metadata.py
+    - name: Add Universe Repository
+      run: sudo add-apt-repository universe
+    - name: Update Packages
+      run: sudo apt-get update
+    - name: Install Dependencies
+      run: sudo apt-get install --assume-yes wine-stable wine64 python3-pip libfuse2
+    - name: Install makelove
+      run: pip3 install git+https://github.com/pfirsich/makelove/
+    - name: Build
+      run: cd main && python3 -m makelove && cd ..
+    - name: Artifact (LÖVE)
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.metadata.outputs.id }}-source
+        path: main/makelove-build/love/${{ env.ARTIFACT_NAME_LOVE }}
+    - name: Artifact (AppImage)
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.metadata.outputs.id }}-linux
+        path: main/makelove-build/appimage/${{ env.ARTIFACT_NAME_APPIMAGE }}
+    - name: Artifact (Win64)
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.metadata.outputs.id }}-win64
+        path: main/makelove-build/win64/${{ env.ARTIFACT_NAME_WIN64 }}
+    - name: Artifact (Win32)
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.metadata.outputs.id }}-win32
+        path: main/makelove-build/win32/${{ env.ARTIFACT_NAME_WIN32 }}
+    - name: Artifact (MacOS)
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.metadata.outputs.id }}-macos
+        path: main/makelove-build/macos/${{ env.ARTIFACT_NAME_MACOS }}

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,7 +1,13 @@
-name: Compile
-on: [push, pull_request]
+name: Create Artifacts
+on:
+  release:
+    types:
+      - created
+  push: {}
+  pull_request: {}
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -11,7 +17,7 @@ jobs:
       name: Checkout Repository
     - name: Extract Metadata
       id: metadata
-      run: python3 main/_DO_NOT_INCLUDE/extract-metadata.py
+      run: python3 main/_DO_NOT_INCLUDE/extract-metadata.py ${{ github.ref }}
     - name: Add Universe Repository
       run: sudo add-apt-repository universe
     - name: Update Packages
@@ -21,29 +27,35 @@ jobs:
     - name: Install makelove
       run: pip3 install git+https://github.com/pfirsich/makelove/
     - name: Build
-      run: cd main && python3 -m makelove && cd ..
+      run: cd main && python3 -m makelove --version-name ${{ steps.metadata.outputs.version }} && cd ..
     - name: Artifact (LÖVE)
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-source
-        path: main/makelove-build/love/${{ env.ARTIFACT_NAME_LOVE }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/love/${{ env.ARTIFACT_NAME_LOVE }}
     - name: Artifact (AppImage)
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-linux
-        path: main/makelove-build/appimage/${{ env.ARTIFACT_NAME_APPIMAGE }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/appimage/${{ env.ARTIFACT_NAME_APPIMAGE }}
     - name: Artifact (Win64)
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-win64
-        path: main/makelove-build/win64/${{ env.ARTIFACT_NAME_WIN64 }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/win64/${{ env.ARTIFACT_NAME_WIN64 }}
     - name: Artifact (Win32)
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-win32
-        path: main/makelove-build/win32/${{ env.ARTIFACT_NAME_WIN32 }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/win32/${{ env.ARTIFACT_NAME_WIN32 }}
     - name: Artifact (MacOS)
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-macos
-        path: main/makelove-build/macos/${{ env.ARTIFACT_NAME_MACOS }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/macos/${{ env.ARTIFACT_NAME_MACOS }}
+    - name: Upload Release Assets
+      if: github.event_name == 'release'
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: main/makelove-build/${{ steps.metadata.outputs.version }}/**/*
+        file_glob: true

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -27,32 +27,42 @@ jobs:
     - name: Install makelove
       run: pip3 install git+https://github.com/pfirsich/makelove/
     - name: Build
-      run: cd main && python3 -m makelove --version-name ${{ steps.metadata.outputs.version }} && cd ..
+      run: |
+        cd main
+        python3 -m makelove --version-name ${{ steps.metadata.outputs.version }}
+        cd ..
+    - name: Rename AppImage # for consistency with every other built artifact
+      run: mv main/makelove-build/${{ steps.metadata.outputs.version }}/appimage/${{ steps.metadata.outputs.id }}.AppImage main/makelove-build/${{ steps.metadata.outputs.version }}/appimage/${{ steps.metadata.outputs.id }}-linux.AppImage
     - name: Artifact (LÖVE)
+      if: github.event_name != 'release'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-source
-        path: main/makelove-build/${{ steps.metadata.outputs.version }}/love/${{ env.ARTIFACT_NAME_LOVE }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/love/${{ steps.metadata.outputs.id }}.love
     - name: Artifact (AppImage)
+      if: github.event_name != 'release'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-linux
-        path: main/makelove-build/${{ steps.metadata.outputs.version }}/appimage/${{ env.ARTIFACT_NAME_APPIMAGE }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/appimage/${{ steps.metadata.outputs.id }}-linux.AppImage
     - name: Artifact (Win64)
+      if: github.event_name != 'release'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-win64
-        path: main/makelove-build/${{ steps.metadata.outputs.version }}/win64/${{ env.ARTIFACT_NAME_WIN64 }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/win64/${{ steps.metadata.outputs.id }}-win64.zip
     - name: Artifact (Win32)
+      if: github.event_name != 'release'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-win32
-        path: main/makelove-build/${{ steps.metadata.outputs.version }}/win32/${{ env.ARTIFACT_NAME_WIN32 }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/win32/${{ steps.metadata.outputs.id }}-win32.zip
     - name: Artifact (MacOS)
+      if: github.event_name != 'release'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.metadata.outputs.id }}-macos
-        path: main/makelove-build/${{ steps.metadata.outputs.version }}/macos/${{ env.ARTIFACT_NAME_MACOS }}
+        path: main/makelove-build/${{ steps.metadata.outputs.version }}/macos/${{ steps.metadata.outputs.id }}-macos.zip
     - name: Upload Release Assets
       if: github.event_name == 'release'
       uses: svenstaro/upload-release-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 ._.*
 Thumbs.db
+makelove-build/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ._.*
 Thumbs.db
 makelove-build/
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # mari0
-Runs on LÖVE 11.2
+Runs on LÖVE 11.4
 
 MIT License

--- a/_DO_NOT_INCLUDE/extract-metadata.py
+++ b/_DO_NOT_INCLUDE/extract-metadata.py
@@ -32,17 +32,17 @@ with open(toml_path, 'r') as toml_file:
     metadata['id'] = re.search(r'^name\s*=\s*"(.+)"', toml).group(1)
     # ensure title is the same as the one in main.lua
     if (_win_title := re.search(r'^ProductName\s*=\s*"(.+)"$', toml, re.MULTILINE)) is None:
-        print('::error file=makelove.toml::Windows product name could not be found')
+        print('::warning file=makelove.toml::Windows product name could not be found')
     if metadata['title'] != _win_title.group(1):
-        print('::error file=makelove.toml::Windows product name does not match game title in main.lua')
+        print('::warning file=makelove.toml::Windows product name does not match game title in main.lua')
     if (_linux_title := re.search(r'\[linux.desktop_file_metadata\]\n+Name\s*=\s*"(.+)"', toml, re.MULTILINE)) is None:
-        print('::error file=makelove.toml::Linux desktop file name could not be found')
+        print('::warning file=makelove.toml::Linux desktop file name could not be found')
     if metadata['title'] != _linux_title.group(1):
-        print('::error file=makelove.toml::Linux desktop file name does not match game title in main.lua')
+        print('::warning file=makelove.toml::Linux desktop file name does not match game title in main.lua')
     if (_mac_title := re.search(r'^CFBundle(?:Display)?Name\s*=\s*"(.+)"$', toml, re.MULTILINE)) is None:
-        print('::error file=makelove.toml::macOS bundle display name could not be found')
+        print('::warning file=makelove.toml::macOS bundle display name could not be found')
     if metadata['title'] != _mac_title.group(1):
-        print('::error file=makelove.toml::macOS bundle display name does not match game title in main.lua')
+        print('::warning file=makelove.toml::macOS bundle display name does not match game title in main.lua')
 
 if len(sys.argv) > 1:
     if (version := re.sub(r'^refs/tags/v?', '', sys.argv[1], count=1)) != sys.argv[1]:

--- a/_DO_NOT_INCLUDE/extract-metadata.py
+++ b/_DO_NOT_INCLUDE/extract-metadata.py
@@ -44,7 +44,7 @@ with open(toml_path, 'r') as toml_file:
     if metadata['title'] != _mac_title.group(1):
         print('::error file=makelove.toml::macOS bundle display name does not match game title in main.lua')
 
-if len(sys.argv > 1):
+if len(sys.argv) > 1:
     if (version := re.sub(r'^refs/tags/v?', '', sys.argv[1], count=1)) != sys.argv[1]:
         metadata['version'] = version
 

--- a/_DO_NOT_INCLUDE/extract-metadata.py
+++ b/_DO_NOT_INCLUDE/extract-metadata.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+'''
+Extracts game metadata from main.lua and makelove.toml
+and writes it out for use by GitHub Actions.
+
+Authored by @qixils
+'''
+
+import os
+from pathlib import Path
+import re
+
+game_path: Path = Path(__file__).parent.parent.resolve()
+main_path: Path = game_path / 'main.lua'
+conf_path: Path = game_path / 'conf.lua'
+toml_path: Path = game_path / 'makelove.toml'
+metadata: dict[str, str] = {}
+
+with open(main_path, 'r') as main_file:
+    main = main_file.read()
+    metadata['title'] = re.search(r'love\.window\.setTitle\(\s*"(.+)"\s*\)', main).group(1)
+    metadata['version'] = re.search(r'^\s*versionstring\s*=\s*"version (.+)"$', main, re.MULTILINE).group(1)
+
+with open(conf_path, 'r') as conf_file:
+    conf = conf_file.read()
+    metadata['love-version'] = re.search(r'^\s*t\.version\s*=\s*"(.+)"$', conf, re.MULTILINE).group(1)
+
+with open(toml_path, 'r') as toml_file:
+    toml = toml_file.read()
+    metadata['id'] = re.search(r'^name\s*=\s*"(.+)"', toml).group(1)
+    # ensure title is the same as the one in main.lua
+    if (_win_title := re.search(r'^ProductName\s*=\s*"(.+)"$', toml, re.MULTILINE)) is None:
+        print('::error file=makelove.toml::Windows product name could not be found')
+    if metadata['title'] != _win_title.group(1):
+        print('::error file=makelove.toml::Windows product name does not match game title in main.lua')
+    if (_linux_title := re.search(r'\[linux.desktop_file_metadata\]\n+Name\s*=\s*"(.+)"', toml, re.MULTILINE)) is None:
+        print('::error file=makelove.toml::Linux desktop file name could not be found')
+    if metadata['title'] != _linux_title.group(1):
+        print('::error file=makelove.toml::Linux desktop file name does not match game title in main.lua')
+    if (_mac_title := re.search(r'^CFBundle(?:Display)?Name\s*=\s*"(.+)"$', toml, re.MULTILINE)) is None:
+        print('::error file=makelove.toml::macOS bundle display name could not be found')
+    if metadata['title'] != _mac_title.group(1):
+        print('::error file=makelove.toml::macOS bundle display name does not match game title in main.lua')
+
+with open(os.environ['GITHUB_OUTPUT'], 'a') as env_file:
+    for key, value in metadata.items():
+        env_file.write(f'{key}={value}\n')

--- a/_DO_NOT_INCLUDE/extract-metadata.py
+++ b/_DO_NOT_INCLUDE/extract-metadata.py
@@ -10,6 +10,7 @@ Authored by @qixils
 import os
 from pathlib import Path
 import re
+import sys
 
 game_path: Path = Path(__file__).parent.parent.resolve()
 main_path: Path = game_path / 'main.lua'
@@ -42,6 +43,10 @@ with open(toml_path, 'r') as toml_file:
         print('::error file=makelove.toml::macOS bundle display name could not be found')
     if metadata['title'] != _mac_title.group(1):
         print('::error file=makelove.toml::macOS bundle display name does not match game title in main.lua')
+
+if len(sys.argv > 1):
+    if (version := re.sub(r'^refs/tags/v?', '', sys.argv[1], count=1)) != sys.argv[1]:
+        metadata['version'] = version
 
 with open(os.environ['GITHUB_OUTPUT'], 'a') as env_file:
     for key, value in metadata.items():

--- a/conf.lua
+++ b/conf.lua
@@ -4,5 +4,5 @@ function love.conf(t)
 	t.console = false
 	--t.screen = false
 	t.modules.physics = false
-	t.version = "11.1"
+	t.version = "11.4"
 end

--- a/main.lua
+++ b/main.lua
@@ -5,6 +5,11 @@
 ]]
 
 function love.load()
+	love.filesystem.setIdentity("mari0")
+	if not love.filesystem.getSaveDirectory():match("LOVE") then
+		love.filesystem.setIdentity("LOVE/mari0")
+	end
+
 	marioversion = 1006
 	versionstring = "version 1.6"
 	shaderlist = love.filesystem.getDirectoryItems( "shaders/" )
@@ -160,8 +165,6 @@ function love.load()
 
 	http = require("socket.http")
 	http.TIMEOUT = 1
-
-	love.filesystem.setIdentity("mari0")
 
 	updatenotification = false
 	if getupdate() then

--- a/makelove.toml
+++ b/makelove.toml
@@ -1,0 +1,23 @@
+name = "mari0"
+default_targets = ["win32", "win64", "appimage", "macos"]
+build_directory = "makelove-build"
+icon_file = "_DO_NOT_INCLUDE/icon.png"
+
+love_files = [
+    "::git-ls-tree::",
+    "-*/.*",
+    "-./_DO_NOT_INCLUDE/*",
+]
+
+[windows.exe_metadata]
+ProductName = "Mari0"
+CompanyName = "Stabyourself.net"
+LegalCopyright = "Copyright © 2006-2023 Maurice Guégan"
+
+[linux.desktop_file_metadata]
+Name = "Mari0"
+
+[macos.app_metadata]
+CFBundleName = "Mari0"
+CFBundleIdentifier = "net.stabyourself"
+NSHumanReadableCopyright = "Copyright © 2006-2023 Maurice Guégan"

--- a/physics.lua
+++ b/physics.lua
@@ -1,6 +1,6 @@
 --[[
 	PHYSICS LIBRARY THING
-	WRITTEN BY MAURICE GUÉGAN FOR MARI0
+	WRITTEN BY MAURICE GUÃ‰GAN FOR MARI0
 	DON'T STEAL MY SHIT
 	Licensed under the same license as the game itself.
 ]]--

--- a/variables.lua
+++ b/variables.lua
@@ -1,6 +1,6 @@
 --SETABLE VARS--
 --almost all vars are in "blocks", "blocks per second" or just "seconds". Should be obvious enough what's what.
-epsilon = 0.000000000000001
+epsilon = 0.000000001
 portalgundelay = 0.2
 gellifetime = 2
 bulletbilllifetime = 20


### PR DESCRIPTION
Automatically compiles executable artifacts (i.e. `.exe`s, `.app`s, and `.AppImage`s) for every commit/pull request. Also, should a v1.6.3 ever be released to GitHub, it will also automatically upload the artifacts to releases as well

This one doesn't close any issues but cmon who doesn't want free and easy proper `.AppImage`s for Linux :D 

edit: just remembered these will read save files from a different directory than 1.6, marking as draft for now