### PR TITLE
Fix menu prompt, and remove dead frames on level load

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -1896,7 +1896,7 @@ function updatesplitscreen()
 end
 
 function startlevel(level)
-	skipupdate = true
+	--skipupdate = true
 	love.audio.stop()
 
 	local sublevel = false
@@ -2604,7 +2604,7 @@ function game_keypressed(key, unicode)
 				pausemenuselected2 = 1
 			elseif (key == "right" or key == "d") then
 				pausemenuselected2 = 2
-			elseif (key == "return" or key == "enter" or key == "kpenter" or key == " ") then
+			elseif (key == "return" or key == "enter" or key == "kpenter" or key == "space") then
 				if pausemenuselected2 == 1 then
 					love.audio.stop()
 					pausemenuopen = false

--- a/main.lua
+++ b/main.lua
@@ -809,7 +809,8 @@ function love.update(dt)
 		menu_update(dt)
 	elseif gamestate == "levelscreen" or gamestate == "gameover" or gamestate == "sublevelscreen" or gamestate == "mappackfinished" then
 		levelscreen_update(dt)
-	elseif gamestate == "game" then
+	end
+	if gamestate == "game" then
 		game_update(dt)
 	elseif gamestate == "intro" then
 		intro_update(dt)


### PR DESCRIPTION
Fixes the spacebar not advancing the pause menu prompt to return to the main menu. Also removes the 2 dead frames after loading a level. The latter frame seems to be intentional, but I could not find any useful role it played.