### PR TITLE
Speedrun Timer

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -1065,20 +1065,6 @@ function game_draw()
 			end
 		end
 
-		if speedtimer then
-			if levelfinished and (not nextlevelexists or (levelfinishtype == "castle" and levelfinishedmisc2 == 2)) then
-				love.graphics.setColor(0.2, 1.0, 0.2, 1)
-			else
-				love.graphics.setColor(1, 1, 1, 1)
-			end
-
-			local total_text = "total " .. format_speed_time(speedtotaltime)
-			properprint(total_text, uispace*4 - 8*total_text:len()*scale - 20, timer_y*scale)
-
-			local level_text = "level " .. format_speed_time(speedleveltime)
-			properprint(level_text, uispace*4 - 8*level_text:len()*scale - 20, (timer_y+8)*scale)
-		end
-
 		love.graphics.setColor(1, 1, 1)
 		--vines
 		for j, w in pairs(objects["vine"]) do
@@ -1767,6 +1753,22 @@ function game_draw()
 					properprint(count, (width*8-72+(i-1)*20-string.len(count)*8)*scale, 205*scale)
 				end
 			end
+		end
+
+		--speedrun timer
+		if speedtimer then
+			local textcolor = {1, 1, 1, 1}
+			if levelfinished and (not nextlevelexists or (levelfinishtype == "castle" and levelfinishedmisc2 == 2)) then
+				textcolor = {0.2, 1.0, 0.2, 1.0}
+			end
+
+			local bordercolor = {0.2, 0.2, 0.2, 1.0}
+
+			local total_text = "total " .. format_speed_time(speedtotaltime)
+			borderprint(total_text, uispace*4 - 8*total_text:len()*scale - 20, timer_y*scale, textcolor, bordercolor)
+
+			local level_text = "level " .. format_speed_time(speedleveltime)
+			borderprint(level_text, uispace*4 - 8*level_text:len()*scale - 20, (timer_y+8)*scale, textcolor, bordercolor)
 		end
 
 		love.graphics.translate(-(split-1)*width*16*scale/#splitscreen, 0)

--- a/game.lua
+++ b/game.lua
@@ -60,6 +60,7 @@ function game_load(suspended)
 	mariolevel = 1
 	mariosublevel = 0
 	respawnsublevel = 0
+	speedtotaltime = 0.0
 
 	objects = nil
 	if suspended == true then
@@ -133,6 +134,12 @@ function game_update(dt)
 	--------
 	--GAME--
 	--------
+
+	--speedrun timer
+	if not (levelfinished and (not nextlevelexists or (levelfinishtype == "castle" and levelfinishedmisc2 == 2))) then
+		speedtotaltime = speedtotaltime + dt
+		speedleveltime = speedleveltime + dt
+	end
 
 	--earthquake reset
 	if earthquake > 0 then
@@ -1044,7 +1051,9 @@ function game_draw()
 			properprint(addzeros(math.ceil(mariotime), 3), uispace*3.5-8*scale, 16*scale)
 		end
 
+		local timer_y = 25
 		if players > 1 then
+			timer_y = 35
 			for i = 1, players do
 				local x = (width*16)/players/2 + (width*16)/players*(i-1)
 				if mariolivecount ~= false then
@@ -1054,6 +1063,20 @@ function game_draw()
 					love.graphics.setColor(1, 1, 1, 1)
 				end
 			end
+		end
+
+		if speedtimer then
+			if levelfinished and (not nextlevelexists or (levelfinishtype == "castle" and levelfinishedmisc2 == 2)) then
+				love.graphics.setColor(0.2, 1.0, 0.2, 1)
+			else
+				love.graphics.setColor(1, 1, 1, 1)
+			end
+
+			local total_text = "total " .. format_speed_time(speedtotaltime)
+			properprint(total_text, uispace*4 - 8*total_text:len()*scale - 20, timer_y*scale)
+
+			local level_text = "level " .. format_speed_time(speedleveltime)
+			properprint(level_text, uispace*4 - 8*level_text:len()*scale - 20, (timer_y+8)*scale)
 		end
 
 		love.graphics.setColor(1, 1, 1)
@@ -1919,6 +1942,7 @@ function startlevel(level)
 	end
 
 	--MISC VARS
+	nextlevelexists = getnextlevelexists()
 	everyonedead = false
 	levelfinished = false
 	coinanimation = 1
@@ -3453,6 +3477,16 @@ function nextlevel()
 		marioworld = marioworld + 1
 	end
 	levelscreen_load("next")
+end
+
+function getnextlevelexists()
+	local nextmariolevel = mariolevel + 1
+	local nextmarioworld = marioworld
+	if nextmariolevel > 4 then
+		nextmariolevel = 1
+		nextmarioworld = nextmarioworld + 1
+	end
+	return love.filesystem.getInfo("mappacks/" .. mappack .. "/" .. nextmarioworld .. "-" .. nextmariolevel .. ".txt")
 end
 
 function warpzone(i)

--- a/levelscreen.lua
+++ b/levelscreen.lua
@@ -1,4 +1,9 @@
+speedleveltime = 0.0
+local levelscreenreason = "initial"
+
 function levelscreen_load(reason, i)
+	levelscreenreason = reason
+
 	if reason ~= "sublevel" and reason ~= "vine" and testlevel then
 		marioworld = testlevelworld
 		mariolevel = testlevellevel
@@ -85,6 +90,11 @@ end
 function levelscreen_update(dt)
 	levelscreentimer = levelscreentimer + dt
 	if (levelscreentimer-blacktime) > -epsilon then -- epsilon ensures that the delay is consistent through floating point errors
+		--reset level timer
+		if levelscreenreason == "initial" or levelscreenreason == "next" then
+			speedleveltime = 0.0
+		end
+		--start level
 		if gamestate == "levelscreen" then
 			gamestate = "game"
 			if respawnsublevel ~= 0 then
@@ -200,5 +210,28 @@ function levelscreen_draw()
 		properprint(marioworld .. "-" .. mariolevel, uispace*2.5 - 12*scale, 16*scale)
 
 		properprint("time", uispace*3.5 - 16*scale, 8*scale)
+
+		if speedtimer then
+			local timer_y = 25
+			if speedtotaltime > 0 then
+				if gamestate == "mappackfinished" then
+					love.graphics.setColor(0.2, 1.0, 0.2, 1)
+				else
+					love.graphics.setColor(1, 1, 1, 1)
+				end
+				local total_text = "total " .. format_speed_time(speedtotaltime)
+				properprint(total_text, uispace*4 - 8*total_text:len()*scale - 20, timer_y*scale)
+			end
+
+			if speedleveltime > 0 then
+				if levelscreenreason == "initial" or levelscreenreason == "next" then
+					love.graphics.setColor(0.2, 1.0, 0.2, 1)
+				else
+					love.graphics.setColor(1, 1, 1, 1)
+				end
+				local level_text = "level " .. format_speed_time(speedleveltime)
+				properprint(level_text, uispace*4 - 8*level_text:len()*scale - 20, (timer_y+8)*scale)
+			end
+		end
 	end
 end

--- a/main.lua
+++ b/main.lua
@@ -914,6 +914,10 @@ function saveconfig()
 
 	s = s .. "vsync:" .. vsync .. ";"
 
+	if speedtimer then
+		s = s .. "speedtimer;"
+	end
+
 	if gamefinished then
 		s = s .. "gamefinished;"
 	end
@@ -1052,6 +1056,8 @@ function loadconfig()
 			else
 				vsync = -1
 			end
+		elseif s2[1] == "speedtimer" then
+			speedtimer = true
 		elseif s2[1] == "reachedworlds" then
 			reachedworlds[s2[2]] = {}
 			local s3 = s2[3]:split(",")
@@ -1162,6 +1168,7 @@ function defaultconfig()
 	volume = 1
 	mappack = "smb"
 	vsync = -1
+	speedtimer = false
 
 	reachedworlds = {}
 end
@@ -1187,7 +1194,8 @@ function suspendgame()
 			s = s .. "size/" .. i .."/1|"
 		end
 	end
-	s = s .. "mappack/" .. mappack
+	s = s .. "mappack/" .. mappack .. "|"
+	s = s .. "speedtotaltime/" .. speedtotaltime
 
 	love.filesystem.write("suspend.txt", s)
 
@@ -1224,6 +1232,8 @@ function continuegame()
 			mariosizes[tonumber(split2[2])] = tonumber(split2[3])
 		elseif split2[1] == "mappack" then
 			mappack = split2[2]
+		elseif split2[1] == "speedtotaltime" then
+			speedtotaltime = tonumber(split2[2])
 		end
 	end
 
@@ -1648,6 +1658,24 @@ function properprint(s, x, y)
 			love.graphics.draw(fontimage, fontquads[char], x+((i-1)*8)*scale, y, 0, scale, scale)
 		end
 	end
+end
+
+function format_speed_time(time)
+	--input: float of seconds
+	--output: string of format "00:00.00"
+	local minutes = math.floor(time/60)
+	local seconds = math.floor(time%60)
+	local milliseconds = math.floor((time*100)%100)
+	if minutes < 10 then
+		minutes = "0" .. minutes
+	end
+	if seconds < 10 then
+		seconds = "0" .. seconds
+	end
+	if milliseconds < 10 then
+		milliseconds = "0" .. milliseconds
+	end
+	return minutes .. ":" .. seconds .. "." .. milliseconds
 end
 
 function loadcustombackground()

--- a/main.lua
+++ b/main.lua
@@ -1660,6 +1660,16 @@ function properprint(s, x, y)
 	end
 end
 
+function borderprint(s, x, y, textcolor, bordercolor)
+	local positions = {{-scale, scale}, {scale, scale}, {-scale, -scale}, {scale, -scale}, {0, -scale}, {0, scale}, {scale, 0}, {-scale, 0}, {0, 0}}
+	local color = bordercolor or {0, 0, 0}
+	for i, position in ipairs(positions) do
+		if i == #positions then color = textcolor or {1, 1, 1} end
+		love.graphics.setColor(color)
+		properprint(s, x+position[1], y+position[2])
+	end
+end
+
 function format_speed_time(time)
 	--input: float of seconds
 	--output: string of format "00:00.00"

--- a/main.lua
+++ b/main.lua
@@ -10,8 +10,8 @@ function love.load()
 		love.filesystem.setIdentity("LOVE/mari0")
 	end
 
-	marioversion = 1006
-	versionstring = "version 1.6"
+	marioversion = 10063
+	versionstring = "version 1.6.3"
 	shaderlist = love.filesystem.getDirectoryItems( "shaders/" )
 	dlclist = {"dlc_a_portal_tribute", "dlc_acid_trip", "dlc_escape_the_lab", "dlc_scienceandstuff", "dlc_smb2J", "dlc_the_untitled_game"}
 

--- a/menu.lua
+++ b/menu.lua
@@ -982,7 +982,7 @@ function menu_draw()
 			properprint("you can lock the|mouse with f12", 30*scale, 165*scale)
 
 			love.graphics.setColor(1, 1, 1, 1)
-			properprint(versionstring, 150*scale, 207*scale)
+			properprint(versionstring, (236-(versionstring:len()*8))*scale, 207*scale)
 		elseif optionstab == 4 then
 			love.graphics.setColor(1, 1, 1, 1)
 			if not gamefinished then

--- a/menu.lua
+++ b/menu.lua
@@ -291,51 +291,24 @@ function menu_draw()
 			love.graphics.draw(menuselection, 98*scale, (137+(selection-1)*16)*scale, 0, scale, scale)
 		end
 
-		local start = 9
+		local printfunction = properprint
 		if custombackground then
-			start = 1
+			printfunction = borderprint
 		end
 
-		for i = start, 9 do
-			local tx, ty = -scale, scale
-			love.graphics.setColor(0, 0, 0)
-			if i == 2 then
-				tx, ty = scale, scale
-			elseif i == 3 then
-				tx, ty = -scale, -scale
-			elseif i == 4 then
-				tx, ty = scale, -scale
-			elseif i == 5 then
-				tx, ty = 0, -scale
-			elseif i == 6 then
-				tx, ty = 0, scale
-			elseif i == 7 then
-				tx, ty = scale, 0
-			elseif i == 8 then
-				tx, ty = -scale, 0
-			elseif i == 9 then
-				tx, ty = 0, 0
-				love.graphics.setColor(1, 1, 1)
-			end
-
-			love.graphics.translate(tx, ty)
-
-			if continueavailable then
-				properprint("continue game", 87*scale, 122*scale)
-			end
-
-			properprint("player game", 103*scale, 138*scale)
-
-			properprint("level editor", 95*scale, 154*scale)
-
-			properprint("select mappack", 87*scale, 170*scale)
-
-			properprint("options", 111*scale, 186*scale)
-
-			properprint(players, 87*scale, 138*scale)
-
-			love.graphics.translate(-tx, -ty)
+		if continueavailable then
+			printfunction("continue game", 87*scale, 122*scale)
 		end
+
+		printfunction("player game", 103*scale, 138*scale)
+
+		printfunction("level editor", 95*scale, 154*scale)
+
+		printfunction("select mappack", 87*scale, 170*scale)
+
+		printfunction("options", 111*scale, 186*scale)
+
+		printfunction(players, 87*scale, 138*scale)
 
 		if players > 1 then
 			love.graphics.draw(playerselectimg, 82*scale, 138*scale, 0, scale, scale)

--- a/menu.lua
+++ b/menu.lua
@@ -978,8 +978,21 @@ function menu_draw()
 				properprint("adaptive", (180-64)*scale, 150*scale)
 			end
 
+			if optionsselection == 9 then
+				love.graphics.setColor(1, 1, 1, 1)
+			else
+				love.graphics.setColor(0.4, 0.4, 0.4)
+			end
+
+			properprint("speedrun timer:", 30*scale, 165*scale)
+			if speedtimer then
+				properprint("on", (180-16)*scale, 165*scale)
+			else
+				properprint("off", (180-24)*scale, 165*scale)
+			end
+
 			love.graphics.setColor(0.4, 0.4, 0.4)
-			properprint("you can lock the|mouse with f12", 30*scale, 165*scale)
+			properprint("you can lock the|mouse with f12", 30*scale, 180*scale)
 
 			love.graphics.setColor(1, 1, 1, 1)
 			properprint(versionstring, (236-(versionstring:len()*8))*scale, 207*scale)
@@ -1782,7 +1795,7 @@ function menu_keypressed(key, unicode)
 					optionsselection = 1
 				end
 			elseif optionstab == 3 then
-				if optionsselection < 8 then
+				if optionsselection < 9 then
 					optionsselection = optionsselection + 1
 				else
 					optionsselection = 1
@@ -1807,7 +1820,7 @@ function menu_keypressed(key, unicode)
 				elseif optionstab == 2 then
 					optionsselection = 14
 				elseif optionstab == 3 then
-					optionsselection = 8
+					optionsselection = 9
 				elseif optionstab == 4 and gamefinished then
 					optionsselection = 10
 				end
@@ -1861,6 +1874,8 @@ function menu_keypressed(key, unicode)
 				elseif optionsselection == 8 then
 					vsync = ((vsync + 2) % 3) - 1
 					changescale(scale)
+				elseif optionsselection == 9 then
+					speedtimer = not speedtimer
 				end
 			elseif optionstab == 4 then
 				if optionsselection == 2 then
@@ -1965,6 +1980,8 @@ function menu_keypressed(key, unicode)
 				elseif optionsselection == 8 then
 					vsync = (vsync % 3) - 1
 					changescale(scale)
+				elseif optionsselection == 9 then
+					speedtimer = not speedtimer
 				end
 			elseif optionstab == 4 then
 				if optionsselection == 2 then


### PR DESCRIPTION
Been doing some speedruns again recently and missed the in-game timer from the tasb0t mod, thought I'd recreate it (all my own code) and PR it. Initial draft of this was pretty conservative about when to tick the timer (basically mirroring the vanilla/SMB timer) but this would've excluded things like fireworks and pipe animations from the time which I think should be timed to better incentivize clever routing. So basically the only thing not counted towards the timer now is the level loading screens. Some sample footage attempting to highlight all the minutia can be found below.

https://github.com/Stabyourself/mari0/assets/13265322/4a4d7862-bf0a-4d64-9e76-6373b2b3b403