### PR TITLE
fix: remove redundant setIdentity

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -2604,7 +2604,7 @@ function game_keypressed(key, unicode)
 				pausemenuselected2 = 1
 			elseif (key == "right" or key == "d") then
 				pausemenuselected2 = 2
-			elseif (key == "return" or key == "enter" or key == "kpenter" or key == " ") then
+			elseif (key == "return" or key == "enter" or key == "kpenter" or key == "space") then
 				if pausemenuselected2 == 1 then
 					love.audio.stop()
 					pausemenuopen = false

--- a/musicloader_thread.lua
+++ b/musicloader_thread.lua
@@ -3,8 +3,6 @@ require("love.sound")
 require("love.audio")
 require("love.timer")
 
-love.filesystem.setIdentity("mari0")
-
 local musicpath = "sounds/%s.ogg"
 
 local musiclist = {}


### PR DESCRIPTION
This may have been required at one point but it isn't any longer, as setIdentity now appears to sync across all threads. Fixes #45 