### PR TITLE
Add FPS Limiter

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -969,14 +969,18 @@ function menu_draw()
 				love.graphics.setColor(0.4, 0.4, 0.4)
 			end
 
-			properprint("vsync:", 30*scale, 150*scale)
-			if vsync == 1 then
-				properprint("on", (180-16)*scale, 150*scale)
-			elseif vsync == 0 then
-				properprint("off", (180-24)*scale, 150*scale)
+			properprint("fps:", 30*scale, 150*scale)
+			local fpstext
+			if fps == 1 then
+				fpstext = "full vsync"
+			elseif fps == 0 then
+				fpstext = "unlimited"
+			elseif fps == -1 then
+				fpstext = "adaptive vsync"
 			else
-				properprint("adaptive", (180-64)*scale, 150*scale)
+				fpstext = tostring(fps)
 			end
+			properprint(fpstext, (180-(string.len(fpstext)*8))*scale, 150*scale)
 
 			love.graphics.setColor(0.4, 0.4, 0.4)
 			properprint("you can lock the|mouse with f12", 30*scale, 165*scale)
@@ -1859,8 +1863,12 @@ function menu_keypressed(key, unicode)
 						soundenabled = true
 					end
 				elseif optionsselection == 8 then
-					vsync = ((vsync + 2) % 3) - 1
-					changescale(scale)
+					local index = (fpsoptionsindices[fps] or 0)+1
+					if index > #fpsoptions then
+						index = 1 --wraparound
+					end
+					fps = fpsoptions[index]
+					updatevsync()
 				end
 			elseif optionstab == 4 then
 				if optionsselection == 2 then
@@ -1963,8 +1971,12 @@ function menu_keypressed(key, unicode)
 						playsound(coinsound)
 					end
 				elseif optionsselection == 8 then
-					vsync = (vsync % 3) - 1
-					changescale(scale)
+					local index = (fpsoptionsindices[fps] or 2)-1
+					if index < 1 then
+						index = #fpsoptions --wraparound
+					end
+					fps = fpsoptions[index]
+					updatevsync()
 				end
 			elseif optionstab == 4 then
 				if optionsselection == 2 then

--- a/variables.lua
+++ b/variables.lua
@@ -6,6 +6,13 @@ gellifetime = 2
 bulletbilllifetime = 20
 playertypelist = {"portal", "minecraft", "gelcannon"}
 
+minfps = 60
+mindt = round(1/minfps, 8) --rounding for backwards-compat with old hardcoded mindt
+measuredfpsperiod = 0.5 --how often fps is measured in seconds
+fpsoptions = {1, -1, 0, 60, 120, 144, 240, 360, 480}
+fpsoptionsindices = {} --reverse map for cleaner menu code
+for i, v in pairs(fpsoptions) do fpsoptionsindices[v] = i end
+
 joystickdeadzone = 0.2
 joystickaimdeadzone = 0.5
 


### PR DESCRIPTION
Replaces the VSync options with a general-purpose FPS limiter to reduce the game's CPU/GPU utilization and to make speedrunning tricks consistent. Users can set their FPS to be limited by full vsync, adaptive vsync, unlimited, 60fps, 120fps, etc.

Tried a couple ideas for implementing this but found this frame skipping method to feature the most stable FPS limit (little to no deviations up or down). In my testing, the frame skipping appears to have a negligible performance impact compared to more `love.timer.sleep`-based solutions, which I found to be either very broken (running too fast/slow) or unstable (high variation in frame timing).