### PR TITLE
Properly use new Channel API

### DIFF
--- a/musicloader.lua
+++ b/musicloader.lua
@@ -35,7 +35,7 @@ end
 function music:play(name)
 	if name and soundenabled then
 		if self.loaded[name] == false then
-			local source = self.thread:demand(name)
+			local source = love.thread.getChannel(name):demand()
 			self:onLoad(name, source)
 		end
 		if self.loaded[name] then


### PR DESCRIPTION
This function was ostensibly [removed in LÖVE 0.9](https://love2d.org/wiki/Thread:demand) but I guess its implementation was kept around for backwards compatibility? Breaks lovejs, though, so this PR updates to the proper new API (like the [matching call to `push`](https://github.com/Stabyourself/mari0/blob/57829fd23e783d1a2993b9d64a7f7e6b131e572f/musicloader_thread.lua#L41) already was updated).